### PR TITLE
feat: implement comprehensive MCP tool filtering with static and dynamic support

### DIFF
--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -242,14 +242,18 @@ class Agent(Generic[TContext]):
 
         return None
 
-    async def get_mcp_tools(self) -> list[Tool]:
+    async def get_mcp_tools(
+        self, run_context: RunContextWrapper[TContext] | None = None
+    ) -> list[Tool]:
         """Fetches the available tools from the MCP servers."""
         convert_schemas_to_strict = self.mcp_config.get("convert_schemas_to_strict", False)
-        return await MCPUtil.get_all_function_tools(self.mcp_servers, convert_schemas_to_strict)
+        return await MCPUtil.get_all_function_tools(
+            self.mcp_servers, convert_schemas_to_strict, run_context, self
+        )
 
     async def get_all_tools(self, run_context: RunContextWrapper[Any]) -> list[Tool]:
         """All agent tools, including MCP tools and function tools."""
-        mcp_tools = await self.get_mcp_tools()
+        mcp_tools = await self.get_mcp_tools(run_context)
 
         async def _check_tool_enabled(tool: Tool) -> bool:
             if not isinstance(tool, FunctionTool):

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -26,8 +26,8 @@ from .util import _error_tracing
 from .util._types import MaybeAwaitable
 
 if TYPE_CHECKING:
+
     from .agent import Agent
-    from mcp.types import Tool as MCPTool
 
 ToolParams = ParamSpec("ToolParams")
 

--- a/tests/mcp/helpers.py
+++ b/tests/mcp/helpers.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import shutil
 from typing import Any
@@ -6,6 +7,8 @@ from mcp import Tool as MCPTool
 from mcp.types import CallToolResult, TextContent
 
 from agents.mcp import MCPServer
+from agents.mcp.server import _MCPServerWithClientSession
+from agents.mcp.util import ToolFilter
 
 tee = shutil.which("tee") or ""
 assert tee, "tee not found"
@@ -28,11 +31,41 @@ class DummyStreamsContextManager:
         pass
 
 
+class _TestFilterServer(_MCPServerWithClientSession):
+    """Minimal implementation of _MCPServerWithClientSession for testing tool filtering"""
+
+    def __init__(self, tool_filter: ToolFilter, server_name: str):
+        # Initialize parent class properly to avoid type errors
+        super().__init__(
+            cache_tools_list=False,
+            client_session_timeout_seconds=None,
+            tool_filter=tool_filter,
+        )
+        self._server_name: str = server_name
+        # Override some attributes for test isolation
+        self.session = None
+        self._cleanup_lock = asyncio.Lock()
+
+    def create_streams(self):
+        raise NotImplementedError("Not needed for filtering tests")
+
+    @property
+    def name(self) -> str:
+        return self._server_name
+
+
 class FakeMCPServer(MCPServer):
-    def __init__(self, tools: list[MCPTool] | None = None):
+    def __init__(
+        self,
+        tools: list[MCPTool] | None = None,
+        tool_filter: ToolFilter = None,
+        server_name: str = "fake_mcp_server",
+    ):
         self.tools: list[MCPTool] = tools or []
         self.tool_calls: list[str] = []
         self.tool_results: list[str] = []
+        self.tool_filter = tool_filter
+        self._server_name = server_name
 
     def add_tool(self, name: str, input_schema: dict[str, Any]):
         self.tools.append(MCPTool(name=name, inputSchema=input_schema))
@@ -43,8 +76,16 @@ class FakeMCPServer(MCPServer):
     async def cleanup(self):
         pass
 
-    async def list_tools(self):
-        return self.tools
+    async def list_tools(self, run_context=None, agent=None):
+        tools = self.tools
+
+        # Apply tool filtering using the REAL implementation
+        if self.tool_filter is not None:
+            # Use the real _MCPServerWithClientSession filtering logic
+            filter_server = _TestFilterServer(self.tool_filter, self.name)
+            tools = await filter_server._apply_tool_filter(tools, run_context, agent)
+
+        return tools
 
     async def call_tool(self, tool_name: str, arguments: dict[str, Any] | None) -> CallToolResult:
         self.tool_calls.append(tool_name)
@@ -55,4 +96,4 @@ class FakeMCPServer(MCPServer):
 
     @property
     def name(self) -> str:
-        return "fake_mcp_server"
+        return self._server_name


### PR DESCRIPTION
feat: implement comprehensive MCP tool filtering with static and dynamic support

- Add static tool filtering with allowlist/blocklist support
- Implement dynamic tool filtering with callable functions  
- Support both sync and async filter functions
- Add ToolFilterContext for context-aware filtering
- Update Agent.get_mcp_tools() to pass run_context and agent
- Add comprehensive error handling for filter failures
- Update documentation with filtering examples
- Add extensive test coverage for all filtering scenarios

Breaking change: MCPServer.list_tools() signature now accepts optional
run_context and agent parameters for dynamic filtering support 